### PR TITLE
use a globalref to refer to the inner function

### DIFF
--- a/src/DynamicScope.jl
+++ b/src/DynamicScope.jl
@@ -108,6 +108,7 @@ macro dyn(fn)
         return expr
     end
     call = fn.args[1]
+    call.args[1] = GlobalRef(__module__, call.args[1])
     # add required variables (that aren't already arguments) as extra function arguments
     append!(call.args, setdiff(requires, argprovides))
     pargs = iskwcall(call) ? call.args[3:end] : call.args[2:end]


### PR DESCRIPTION
This may be helpful if you export the macro but not the function, so that the macroexpansion can always refer to the inner function that might not be in scope.